### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/189/891/421189891.geojson
+++ b/data/421/189/891/421189891.geojson
@@ -400,6 +400,9 @@
     },
     "wof:country":"MR",
     "wof:created":1459009639,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66a3145fabdf4cedf2450c5dcde500f9",
     "wof:hierarchy":[
         {
@@ -411,7 +414,7 @@
         }
     ],
     "wof:id":421189891,
-    "wof:lastmodified":1566611999,
+    "wof:lastmodified":1582314085,
     "wof:name":"Nouakchott",
     "wof:parent_id":85674873,
     "wof:placetype":"locality",

--- a/data/856/326/79/85632679.geojson
+++ b/data/856/326/79/85632679.geojson
@@ -996,6 +996,11 @@
     },
     "wof:country":"MR",
     "wof:country_alpha3":"MRT",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"a289526f97755cb3be1be60e266d8392",
     "wof:hierarchy":[
         {
@@ -1010,7 +1015,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611931,
+    "wof:lastmodified":1582314084,
     "wof:name":"Mauritania",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/748/57/85674857.geojson
+++ b/data/856/748/57/85674857.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Tiris Zemmour Region"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d00dbbc33b0a68033467c0dfbbb91c9",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611929,
+    "wof:lastmodified":1582314083,
     "wof:name":"Tiris Zemmour",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/63/85674863.geojson
+++ b/data/856/748/63/85674863.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Brakna Region"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"872af1b873a2a50c74d9a5335c1c8914",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611930,
+    "wof:lastmodified":1582314084,
     "wof:name":"Brakna",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/65/85674865.geojson
+++ b/data/856/748/65/85674865.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Dakhlet Nouadhibou Region"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab15c5232e60d0370c17edcf915f369e",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611930,
+    "wof:lastmodified":1582314084,
     "wof:name":"Dakhlet Nouadhibou",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/69/85674869.geojson
+++ b/data/856/748/69/85674869.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Inchiri Region"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a51cdfd4160b8c3663fce73f04ad2712",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611929,
+    "wof:lastmodified":1582314083,
     "wof:name":"Inchiri",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/73/85674873.geojson
+++ b/data/856/748/73/85674873.geojson
@@ -565,6 +565,9 @@
         "wd:id":"Q859581"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66a3145fabdf4cedf2450c5dcde500f9",
     "wof:hierarchy":[
         {
@@ -580,7 +583,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611929,
+    "wof:lastmodified":1582314083,
     "wof:name":"Nouakchott",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/81/85674881.geojson
+++ b/data/856/748/81/85674881.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Trarza Region"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5583499412e939032583473fd4595a3d",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611930,
+    "wof:lastmodified":1582314083,
     "wof:name":"Trarza",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/85/85674885.geojson
+++ b/data/856/748/85/85674885.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Assaba Region"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"39e7b20013cd5b493f72653ed627ba47",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611931,
+    "wof:lastmodified":1582314084,
     "wof:name":"Assaba",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/87/85674887.geojson
+++ b/data/856/748/87/85674887.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Guidimaka Region"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"daeea065537df5ab65ce666209949aa3",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611930,
+    "wof:lastmodified":1582314083,
     "wof:name":"Guidimaka",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/91/85674891.geojson
+++ b/data/856/748/91/85674891.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Gorgol Region"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee3e1f189bd284698198fd25ac75e7a6",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611930,
+    "wof:lastmodified":1582314084,
     "wof:name":"Gorgol",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/99/85674899.geojson
+++ b/data/856/748/99/85674899.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Adrar Region"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb3fbc7f6f867dffe16665f31d733c53",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611930,
+    "wof:lastmodified":1582314084,
     "wof:name":"Adrar",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/749/01/85674901.geojson
+++ b/data/856/749/01/85674901.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Hodh Ech Chargui Region"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6ea3533e534d465c93367151f0055a7",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611929,
+    "wof:lastmodified":1582314083,
     "wof:name":"Hodh Ech Chargi",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/749/05/85674905.geojson
+++ b/data/856/749/05/85674905.geojson
@@ -279,6 +279,9 @@
         "wk:page":"Hodh El Gharbi Region"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b4daf55cd17b93a7ea1b8a948081630",
     "wof:hierarchy":[
         {
@@ -294,7 +297,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611929,
+    "wof:lastmodified":1582314083,
     "wof:name":"Hodh El Gharbi",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/749/09/85674909.geojson
+++ b/data/856/749/09/85674909.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Tagant Region"
     },
     "wof:country":"MR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ce3d8e01711570c7f832ea81a1568026",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566611929,
+    "wof:lastmodified":1582314083,
     "wof:name":"Tagant",
     "wof:parent_id":85632679,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.