### PR TITLE
Name updates

### DIFF
--- a/data/856/326/79/85632679.geojson
+++ b/data/856/326/79/85632679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":89.770614,
-    "geom:area_square_m":1040007269705.581177,
+    "geom:area_square_m":1040007267920.168701,
     "geom:bbox":"-17.070134,14.721273,-4.833334,27.294444",
     "geom:latitude":20.253806,
     "geom:longitude":-10.337533,
@@ -69,6 +69,9 @@
     "name:arg_x_preferred":[
         "Mauritania"
     ],
+    "name:ary_x_preferred":[
+        "\u0645\u0648\u0631\u064a\u0637\u0627\u0646\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0645\u0648\u0631\u064a\u062a\u0627\u0646\u064a\u0627"
     ],
@@ -89,6 +92,9 @@
     ],
     "name:bam_x_variant":[
         "M\u0254ritani"
+    ],
+    "name:ban_x_preferred":[
+        "Mauritania"
     ],
     "name:bcl_x_preferred":[
         "Mauritanya"
@@ -180,6 +186,12 @@
     "name:dan_x_preferred":[
         "Mauretanien"
     ],
+    "name:deu_at_x_preferred":[
+        "Mauretanien"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Mauretanien"
+    ],
     "name:deu_x_preferred":[
         "Mauretanien"
     ],
@@ -200,6 +212,12 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03b1\u03c5\u03c1\u03b9\u03c4\u03b1\u03bd\u03af\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Mauritania"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Mauritania"
     ],
     "name:eng_x_preferred":[
         "Mauritania"
@@ -269,6 +287,9 @@
     ],
     "name:gag_x_preferred":[
         "Mavritaniya"
+    ],
+    "name:gcr_x_preferred":[
+        "Moritani"
     ],
     "name:gla_x_preferred":[
         "Moratainia"
@@ -445,6 +466,9 @@
     "name:lav_x_preferred":[
         "Maurit\u0101nija"
     ],
+    "name:lez_x_preferred":[
+        "\u041c\u0430\u0432\u0440\u0438\u0442\u0430\u043d\u0438\u044f"
+    ],
     "name:lfn_x_preferred":[
         "Muritania"
     ],
@@ -507,6 +531,9 @@
     ],
     "name:mon_x_preferred":[
         "\u041c\u0430\u0432\u0440\u0438\u0442\u0430\u043d"
+    ],
+    "name:mri_x_preferred":[
+        "Maurit\u0101nia"
     ],
     "name:mrj_x_preferred":[
         "\u041c\u0430\u0432\u0440\u0438\u0442\u0430\u043d\u0438"
@@ -611,6 +638,9 @@
     "name:pol_x_preferred":[
         "Mauretania"
     ],
+    "name:por_br_x_preferred":[
+        "Maurit\u00e2nia"
+    ],
     "name:por_x_preferred":[
         "Maurit\u00e2nia"
     ],
@@ -674,8 +704,14 @@
     "name:sme_x_variant":[
         "Mauret\u00e1nia"
     ],
+    "name:smo_x_preferred":[
+        "Mauritania"
+    ],
     "name:sna_x_preferred":[
         "Mauritania"
+    ],
+    "name:snd_x_preferred":[
+        "\u0645\u0648\u0631\u064a\u0637\u0627\u0646\u064a\u0627"
     ],
     "name:som_x_preferred":[
         "Mauritania"
@@ -697,6 +733,12 @@
     ],
     "name:srd_x_preferred":[
         "Maurit\u00e0nia"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u041c\u0430\u0443\u0440\u0438\u0442\u0430\u043d\u0438\u0458\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Mauritanija"
     ],
     "name:srp_x_preferred":[
         "\u041c\u0430\u0443\u0440\u0438\u0442\u0430\u043d\u0438\u0458\u0430"
@@ -724,6 +766,9 @@
     ],
     "name:szl_x_preferred":[
         "Mauryta\u0144ijo"
+    ],
+    "name:szy_x_preferred":[
+        "Mauritania"
     ],
     "name:tam_x_preferred":[
         "\u0bae\u0bc2\u0bb0\u0bbf\u0ba4\u0bcd\u0ba4\u0bbe\u0ba9\u0bbf\u0baf\u0bbe"
@@ -848,8 +893,32 @@
     "name:yue_x_preferred":[
         "\u6bdb\u91cc\u5854\u5c3c\u4e9e"
     ],
+    "name:zea_x_preferred":[
+        "Mauritani\u00eb"
+    ],
+    "name:zha_x_preferred":[
+        "Mauritania"
+    ],
+    "name:zho_cn_x_preferred":[
+        "\u6bdb\u91cc\u5854\u5c3c\u4e9a"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6bdb\u91cc\u5854\u5c3c\u4e9e"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Mauritania"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u6bdb\u91cc\u5854\u5c3c\u4e9a"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u6bdb\u91cc\u5854\u5c3c\u4e9a"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u6bdb\u91cc\u5854\u5c3c\u4e9a"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u8305\u5229\u5854\u5c3c\u4e9e"
     ],
     "name:zho_x_preferred":[
         "\u6bdb\u91cc\u5854\u5c3c\u4e9a"
@@ -1016,7 +1085,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1583797396,
+    "wof:lastmodified":1587428767,
     "wof:name":"Mauritania",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.