### PR TITLE
mr concordances, placetype local, and more

### DIFF
--- a/data/109/169/479/1/1091694791.geojson
+++ b/data/109/169/479/1/1091694791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.600494,
-    "geom:area_square_m":7164740064.826599,
+    "geom:area_square_m":7164740832.803299,
     "geom:bbox":"-12.748718,14.718971,-11.792134,15.857117",
     "geom:latitude":15.217764,
     "geom:longitude":-12.250178,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MR.GD.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879516,
-    "wof:geomhash":"0bdbc2b3aafd596e5e52dc3396682718",
+    "wof:geomhash":"ab20cb52e0d035f56b37133f9c3218a2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091694791,
-    "wof:lastmodified":1627522382,
+    "wof:lastmodified":1695886033,
     "wof:name":"Selibaby",
     "wof:parent_id":85674887,
     "wof:placetype":"county",

--- a/data/109/169/481/1/1091694811.geojson
+++ b/data/109/169/481/1/1091694811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.202419,
-    "geom:area_square_m":2411590309.365713,
+    "geom:area_square_m":2411590309.365697,
     "geom:bbox":"-13.1669653198,15.1240844727,-12.5375520755,15.9218713683",
     "geom:latitude":15.531775,
     "geom:longitude":-12.836233,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"MR.GO.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879517,
-    "wof:geomhash":"0c2792ab43a4f4c2ce7f8c06a3369613",
+    "wof:geomhash":"e3d2daf00dba16f33bfb3fd1af2cbdf4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091694811,
-    "wof:lastmodified":1566611991,
+    "wof:lastmodified":1695886849,
     "wof:name":"Maghama",
     "wof:parent_id":85674891,
     "wof:placetype":"county",

--- a/data/109/169/484/1/1091694841.geojson
+++ b/data/109/169/484/1/1091694841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.303165,
-    "geom:area_square_m":3609027407.560209,
+    "geom:area_square_m":3609026036.7724,
     "geom:bbox":"-12.267578,15.191501,-11.500305,16.056274",
     "geom:latitude":15.688434,
     "geom:longitude":-11.879885,
@@ -85,9 +85,10 @@
         "hasc:id":"MR.GD.OY",
         "wd:id":"Q3044595"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879518,
-    "wof:geomhash":"b41ef37eb0c598a626f2085b9c05238f",
+    "wof:geomhash":"dbfba979582d0190f2c6bd9cbeef4758",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1091694841,
-    "wof:lastmodified":1690846469,
+    "wof:lastmodified":1695886849,
     "wof:name":"Ould Yenge",
     "wof:parent_id":85674887,
     "wof:placetype":"county",

--- a/data/109/169/487/3/1091694873.geojson
+++ b/data/109/169/487/3/1091694873.geojson
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"MR.HC.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879519,
-    "wof:geomhash":"499005ea7f2dc990e86417cc43577ada",
+    "wof:geomhash":"463d6ebcf5fd1434e8e903f8815fa4aa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091694873,
-    "wof:lastmodified":1566611992,
+    "wof:lastmodified":1695886849,
     "wof:name":"Amourj",
     "wof:parent_id":85674901,
     "wof:placetype":"county",

--- a/data/109/169/491/1/1091694911.geojson
+++ b/data/109/169/491/1/1091694911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.866178,
-    "geom:area_square_m":10304632193.734669,
+    "geom:area_square_m":10304632193.73469,
     "geom:bbox":"-11.7116336603,15.1052713683,-10.5825830293,16.3059082031",
     "geom:latitude":15.818668,
     "geom:longitude":-11.121115,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"MR.AS.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879520,
-    "wof:geomhash":"473b058fd4788444a987155947dc04a6",
+    "wof:geomhash":"bba94d677080968510b73faef41d0e13",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091694911,
-    "wof:lastmodified":1566611989,
+    "wof:lastmodified":1695886849,
     "wof:name":"Kankossa",
     "wof:parent_id":85674885,
     "wof:placetype":"county",

--- a/data/109/169/494/7/1091694947.geojson
+++ b/data/109/169/494/7/1091694947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.751771,
-    "geom:area_square_m":8941285116.691589,
+    "geom:area_square_m":8941285116.691547,
     "geom:bbox":"-9.94223366027,15.4222713683,-8.85632324219,16.3919067383",
     "geom:latitude":15.874708,
     "geom:longitude":-9.425616,
@@ -85,9 +85,10 @@
         "hasc:id":"MR.HG.KB",
         "wd:id":"Q3044647"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879521,
-    "wof:geomhash":"a2e7e6d3b768450d8aefa04eb1448d1e",
+    "wof:geomhash":"06a52d991887c3c6c7d4f23b22cf0ee9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1091694947,
-    "wof:lastmodified":1566611992,
+    "wof:lastmodified":1695886849,
     "wof:name":"Kobeni",
     "wof:parent_id":85674905,
     "wof:placetype":"county",

--- a/data/109/169/495/5/1091694955.geojson
+++ b/data/109/169/495/5/1091694955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.358004,
-    "geom:area_square_m":4254448951.152836,
+    "geom:area_square_m":4254446300.133576,
     "geom:bbox":"-13.713196,15.606873,-12.726434,16.403911",
     "geom:latitude":16.038286,
     "geom:longitude":-13.185531,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MR.GO.KD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879522,
-    "wof:geomhash":"da26bb332d82662d2d40a77498f502b9",
+    "wof:geomhash":"c12e9cefc7d34549dd4173e4c572faf2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091694955,
-    "wof:lastmodified":1627522382,
+    "wof:lastmodified":1695886033,
     "wof:name":"Kaedi",
     "wof:parent_id":85674891,
     "wof:placetype":"county",

--- a/data/109/169/498/5/1091694985.geojson
+++ b/data/109/169/498/5/1091694985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055944,
-    "geom:area_square_m":664038892.372159,
+    "geom:area_square_m":664038593.541113,
     "geom:bbox":"-13.965027,16.107117,-13.632385,16.463371",
     "geom:latitude":16.266232,
     "geom:longitude":-13.778992,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"MR.BR.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879524,
-    "wof:geomhash":"eb928fc8a9c7ae5f44f12267e7f756ac",
+    "wof:geomhash":"d6a4ab2085831101c970b225d17e9f9e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1091694985,
-    "wof:lastmodified":1627522382,
+    "wof:lastmodified":1695886033,
     "wof:name":"M'Bagne",
     "wof:parent_id":85674863,
     "wof:placetype":"county",

--- a/data/109/169/500/9/1091695009.geojson
+++ b/data/109/169/500/9/1091695009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.463063,
-    "geom:area_square_m":5502761196.150782,
+    "geom:area_square_m":5502765631.643944,
     "geom:bbox":"-12.991734,15.538879,-12.004822,16.489685",
     "geom:latitude":16.045631,
     "geom:longitude":-12.525187,
@@ -84,9 +84,10 @@
         "hasc:id":"MR.GO.MT",
         "wd:id":"Q3044653"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879525,
-    "wof:geomhash":"bb39ba6e236b7bb7c5abd230ab1afede",
+    "wof:geomhash":"61b5427313eefad36585025bead75862",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091695009,
-    "wof:lastmodified":1690846470,
+    "wof:lastmodified":1695886849,
     "wof:name":"M'Bout",
     "wof:parent_id":85674891,
     "wof:placetype":"county",

--- a/data/109/169/503/9/1091695039.geojson
+++ b/data/109/169/503/9/1091695039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.430062,
-    "geom:area_square_m":5113439208.299421,
+    "geom:area_square_m":5113435487.620802,
     "geom:bbox":"-9.067505,15.495117,-8.358705,16.531921",
     "geom:latitude":15.928365,
     "geom:longitude":-8.722233,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MR.HC.DJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879527,
-    "wof:geomhash":"46a4b5816b5599d86e857421a46811e8",
+    "wof:geomhash":"7ede19d6b48f0eaea874db342aa34ecd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091695039,
-    "wof:lastmodified":1627522382,
+    "wof:lastmodified":1695886033,
     "wof:name":"Djigueni",
     "wof:parent_id":85674901,
     "wof:placetype":"county",

--- a/data/109/169/506/9/1091695069.geojson
+++ b/data/109/169/506/9/1091695069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.863067,
-    "geom:area_square_m":10257962781.060034,
+    "geom:area_square_m":10257962781.059969,
     "geom:bbox":"-10.8737792969,15.4198713683,-9.83883366027,16.5671713683",
     "geom:latitude":16.010716,
     "geom:longitude":-10.32069,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"MR.HG.TT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879528,
-    "wof:geomhash":"158dcec39dca2e4960c8d73049252820",
+    "wof:geomhash":"489a466dcad7dc9634d3a16423104daa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091695069,
-    "wof:lastmodified":1566611990,
+    "wof:lastmodified":1695886849,
     "wof:name":"Tintane",
     "wof:parent_id":85674905,
     "wof:placetype":"county",

--- a/data/109/169/509/9/1091695099.geojson
+++ b/data/109/169/509/9/1091695099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095375,
-    "geom:area_square_m":1130841342.304998,
+    "geom:area_square_m":1130839247.865205,
     "geom:bbox":"-14.155404,16.271087,-13.750734,16.665071",
     "geom:latitude":16.485812,
     "geom:longitude":-13.913207,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MR.BR.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879529,
-    "wof:geomhash":"c47275558cfb9bcd2631916dbf4cdc57",
+    "wof:geomhash":"d7fbbe255335830ac57fe1a0d1d08877",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091695099,
-    "wof:lastmodified":1627522382,
+    "wof:lastmodified":1695886033,
     "wof:name":"Bababe",
     "wof:parent_id":85674863,
     "wof:placetype":"county",

--- a/data/109/169/512/9/1091695129.geojson
+++ b/data/109/169/512/9/1091695129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142661,
-    "geom:area_square_m":1689854991.076315,
+    "geom:area_square_m":1689854991.076335,
     "geom:bbox":"-14.9522705078,16.4868883424,-13.9118336603,16.8064713683",
     "geom:latitude":16.675203,
     "geom:longitude":-14.426194,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MR.BR.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879530,
-    "wof:geomhash":"9f883f5db5836caaa4d8bcf00069a46a",
+    "wof:geomhash":"c774b2295c8c22873b14b30908c0a229",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091695129,
-    "wof:lastmodified":1566611994,
+    "wof:lastmodified":1695886849,
     "wof:name":"Boghe",
     "wof:parent_id":85674863,
     "wof:placetype":"county",

--- a/data/109/169/515/9/1091695159.geojson
+++ b/data/109/169/515/9/1091695159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108059,
-    "geom:area_square_m":1280291129.771319,
+    "geom:area_square_m":1280289780.535216,
     "geom:bbox":"-16.002532,16.474915,-15.497734,16.842171",
     "geom:latitude":16.624299,
     "geom:longitude":-15.710551,
@@ -161,9 +161,10 @@
     "wof:concordances":{
         "hasc:id":"MR.TR.RO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879531,
-    "wof:geomhash":"e0f7f414e7f62263926f66b4156004c0",
+    "wof:geomhash":"3410bfdfd2d7a6744165d5d844464d62",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":1091695159,
-    "wof:lastmodified":1636494846,
+    "wof:lastmodified":1695886621,
     "wof:name":"Rosso",
     "wof:parent_id":85674881,
     "wof:placetype":"county",

--- a/data/109/169/517/3/1091695173.geojson
+++ b/data/109/169/517/3/1091695173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.145297,
-    "geom:area_square_m":1723061414.475443,
+    "geom:area_square_m":1723063465.121169,
     "geom:bbox":"-13.221146,16.209071,-12.731873,16.859314",
     "geom:latitude":16.452538,
     "geom:longitude":-12.970945,
@@ -87,9 +87,10 @@
         "hasc:id":"MR.GO.MN",
         "wd:id":"Q3044661"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879532,
-    "wof:geomhash":"eb6743bf0cb7048e8d6098f9c9a59aab",
+    "wof:geomhash":"0dc0242ba7d471c7b0d9b0bb0eec0cd7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1091695173,
-    "wof:lastmodified":1690846470,
+    "wof:lastmodified":1695886849,
     "wof:name":"Monguel",
     "wof:parent_id":85674891,
     "wof:placetype":"county",

--- a/data/109/169/519/3/1091695193.geojson
+++ b/data/109/169/519/3/1091695193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.39992,
-    "geom:area_square_m":16621805607.170815,
+    "geom:area_square_m":16621804795.33663,
     "geom:bbox":"-6.756634,15.495371,-5.327134,16.884871",
     "geom:latitude":16.208268,
     "geom:longitude":-6.014681,
@@ -90,9 +90,10 @@
         "hasc:id":"MR.HC.BA",
         "wd:id":"Q3044601"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879533,
-    "wof:geomhash":"198d77f560ed5d2b8e73146aab24cb47",
+    "wof:geomhash":"80dc14956302d1111ac82a71c93cdebd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091695193,
-    "wof:lastmodified":1690846470,
+    "wof:lastmodified":1695886849,
     "wof:name":"Bassikounou",
     "wof:parent_id":85674901,
     "wof:placetype":"county",

--- a/data/109/169/522/7/1091695227.geojson
+++ b/data/109/169/522/7/1091695227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.203704,
-    "geom:area_square_m":2413713293.625236,
+    "geom:area_square_m":2413713293.625278,
     "geom:bbox":"-16.5152336603,16.0623168945,-15.9507336603,16.9990713683",
     "geom:latitude":16.610767,
     "geom:longitude":-16.273319,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"MR.TR.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879534,
-    "wof:geomhash":"e6925bb630b459d910a2f2d79902f471",
+    "wof:geomhash":"1ed2a200c8ed87ddfb769b89b070319d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091695227,
-    "wof:lastmodified":1566611993,
+    "wof:lastmodified":1695886849,
     "wof:name":"Keur-Macene",
     "wof:parent_id":85674881,
     "wof:placetype":"county",

--- a/data/109/169/526/1/1091695261.geojson
+++ b/data/109/169/526/1/1091695261.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.970611,
-    "geom:area_square_m":11525497090.683475,
+    "geom:area_square_m":11525493563.145592,
     "geom:bbox":"-8.750427,15.495483,-7.657634,17.023045",
     "geom:latitude":16.185651,
     "geom:longitude":-8.19278,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"MR.HC.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879535,
-    "wof:geomhash":"2383061cbe4126b4e3e8c1850ad73fc4",
+    "wof:geomhash":"b9896a09b5c44e16b951fbf2d7bc00ee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091695261,
-    "wof:lastmodified":1636494845,
+    "wof:lastmodified":1695886620,
     "wof:name":"Timbedra",
     "wof:parent_id":85674901,
     "wof:placetype":"county",

--- a/data/109/169/529/5/1091695295.geojson
+++ b/data/109/169/529/5/1091695295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.839796,
-    "geom:area_square_m":9961089594.547775,
+    "geom:area_square_m":9961089613.407019,
     "geom:bbox":"-7.924334,15.792271,-6.711334,17.028871",
     "geom:latitude":16.409599,
     "geom:longitude":-7.316029,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"MR.HC.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879536,
-    "wof:geomhash":"bbfa6356c6514aa119dd231a6dd9ccd3",
+    "wof:geomhash":"524af1f27b3ac7b7679308a9b6715303",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1091695295,
-    "wof:lastmodified":1636494845,
+    "wof:lastmodified":1695886620,
     "wof:name":"Nema",
     "wof:parent_id":85674901,
     "wof:placetype":"county",

--- a/data/109/169/531/9/1091695319.geojson
+++ b/data/109/169/531/9/1091695319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.223143,
-    "geom:area_square_m":2640289383.184399,
+    "geom:area_square_m":2640291215.343212,
     "geom:bbox":"-12.272734,16.534471,-11.659234,17.193481",
     "geom:latitude":16.882813,
     "geom:longitude":-11.988141,
@@ -91,9 +91,10 @@
         "hasc:id":"MR.AS.GU",
         "wd:id":"Q27754095"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879538,
-    "wof:geomhash":"d2e24c88f02f3285c8fee4a264a86cbf",
+    "wof:geomhash":"2e3fe7e0e66a91e7303877445814d850",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1091695319,
-    "wof:lastmodified":1690846470,
+    "wof:lastmodified":1695886849,
     "wof:name":"Guerrou",
     "wof:parent_id":85674885,
     "wof:placetype":"county",

--- a/data/109/169/535/3/1091695353.geojson
+++ b/data/109/169/535/3/1091695353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.559268,
-    "geom:area_square_m":6624581345.503875,
+    "geom:area_square_m":6624581345.503909,
     "geom:bbox":"-12.8389892578,16.0507202148,-11.9443336603,17.2755126953",
     "geom:latitude":16.674785,
     "geom:longitude":-12.393778,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"MR.AS.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879539,
-    "wof:geomhash":"f0d798142bd27e7c0f57e7764ea5e807",
+    "wof:geomhash":"897090ca77c429882fc4df02b8d2e359",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091695353,
-    "wof:lastmodified":1566611988,
+    "wof:lastmodified":1695886849,
     "wof:name":"Barkeol",
     "wof:parent_id":85674885,
     "wof:placetype":"county",

--- a/data/109/169/538/5/1091695385.geojson
+++ b/data/109/169/538/5/1091695385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.465779,
-    "geom:area_square_m":5509526052.123646,
+    "geom:area_square_m":5509523039.791023,
     "geom:bbox":"-15.501932,16.543518,-14.562536,17.364471",
     "geom:latitude":16.936387,
     "geom:longitude":-15.07276,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MR.TR.RK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879540,
-    "wof:geomhash":"50c40f0b05b8ac65bfec5e62ba6c8be6",
+    "wof:geomhash":"49670953ca1b1510ce8818bfc104adb3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091695385,
-    "wof:lastmodified":1627522382,
+    "wof:lastmodified":1695886033,
     "wof:name":"R'kiz",
     "wof:parent_id":85674881,
     "wof:placetype":"county",

--- a/data/109/169/541/5/1091695415.geojson
+++ b/data/109/169/541/5/1091695415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.027126,
-    "geom:area_square_m":12165660986.724239,
+    "geom:area_square_m":12165665528.114269,
     "geom:bbox":"-12.052734,15.900513,-10.698425,17.478088",
     "geom:latitude":16.684116,
     "geom:longitude":-11.413202,
@@ -155,9 +155,10 @@
     "wof:concordances":{
         "hasc:id":"MR.AS.KF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879541,
-    "wof:geomhash":"a529389e71f4b40125ae4c4b357743e1",
+    "wof:geomhash":"e20b7987be6d160329e70b0bc8d4b838",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":1091695415,
-    "wof:lastmodified":1636494846,
+    "wof:lastmodified":1695886621,
     "wof:name":"Kiffa",
     "wof:parent_id":85674885,
     "wof:placetype":"county",

--- a/data/109/169/543/1/1091695431.geojson
+++ b/data/109/169/543/1/1091695431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.500702,
-    "geom:area_square_m":17758620654.377102,
+    "geom:area_square_m":17758632824.146336,
     "geom:bbox":"-10.005034,16.175671,-8.289185,17.556519",
     "geom:latitude":16.851361,
     "geom:longitude":-9.273798,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MR.HG.AI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879542,
-    "wof:geomhash":"829c60be41b808e4a7aabfa9f5b382ff",
+    "wof:geomhash":"431af3cfe39cfd2345d396cfa9785094",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091695431,
-    "wof:lastmodified":1627522381,
+    "wof:lastmodified":1695886032,
     "wof:name":"Aioun",
     "wof:parent_id":85674905,
     "wof:placetype":"county",

--- a/data/109/169/546/5/1091695465.geojson
+++ b/data/109/169/546/5/1091695465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.563123,
-    "geom:area_square_m":6655124044.881127,
+    "geom:area_square_m":6655124044.881135,
     "geom:bbox":"-16.2864336603,16.6330713683,-15.2567336603,17.6024780273",
     "geom:latitude":17.106503,
     "geom:longitude":-15.754973,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"MR.TR.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879543,
-    "wof:geomhash":"c0096a99f84d228675fc2af65338f10f",
+    "wof:geomhash":"fbdcc2f2ae3007dc0d22fb8f9fe16b24",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1091695465,
-    "wof:lastmodified":1566611994,
+    "wof:lastmodified":1695886849,
     "wof:name":"Mederdra",
     "wof:parent_id":85674881,
     "wof:placetype":"county",

--- a/data/109/169/549/7/1091695497.geojson
+++ b/data/109/169/549/7/1091695497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.119459,
-    "geom:area_square_m":13230696434.862171,
+    "geom:area_square_m":13230696305.59186,
     "geom:bbox":"-11.095825,16.511771,-9.722595,17.7229",
     "geom:latitude":17.101384,
     "geom:longitude":-10.456579,
@@ -84,9 +84,10 @@
         "hasc:id":"MR.HG.TA",
         "wd:id":"Q27754089"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879544,
-    "wof:geomhash":"eedd923fc51b955e6ad00af5b4605043",
+    "wof:geomhash":"e219fe6993b176acccb7119fd94173d3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091695497,
-    "wof:lastmodified":1690846471,
+    "wof:lastmodified":1695886849,
     "wof:name":"Tamchekett",
     "wof:parent_id":85674905,
     "wof:placetype":"county",

--- a/data/109/169/553/3/1091695533.geojson
+++ b/data/109/169/553/3/1091695533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.34589,
-    "geom:area_square_m":15914191576.47994,
+    "geom:area_square_m":15914192492.666639,
     "geom:bbox":"-14.733215,16.289673,-12.815125,17.800068",
     "geom:latitude":16.98863,
     "geom:longitude":-13.641721,
@@ -137,9 +137,10 @@
     "wof:concordances":{
         "hasc:id":"MR.BR.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879545,
-    "wof:geomhash":"5909f2732edefaee0a610cd8e25ba08b",
+    "wof:geomhash":"54e0f1720816b9bcb60da77ece60b5a9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1091695533,
-    "wof:lastmodified":1636494845,
+    "wof:lastmodified":1695886620,
     "wof:name":"Aleg",
     "wof:parent_id":85674863,
     "wof:placetype":"county",

--- a/data/109/169/556/5/1091695565.geojson
+++ b/data/109/169/556/5/1091695565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022498,
-    "geom:area_square_m":264491662.09382,
+    "geom:area_square_m":264491662.093819,
     "geom:bbox":"-16.030538,17.976501,-15.887573,18.140503",
     "geom:latitude":18.059043,
     "geom:longitude":-15.9568,
@@ -393,7 +393,7 @@
     ],
     "wof:country":"MR",
     "wof:created":1473879546,
-    "wof:geomhash":"1121c199daa60e940b32fc8a73ee8630",
+    "wof:geomhash":"5f36d2e10a0af9f93d9767b129cdaf25",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -403,7 +403,7 @@
         }
     ],
     "wof:id":1091695565,
-    "wof:lastmodified":1608002940,
+    "wof:lastmodified":1695886414,
     "wof:name":"Nouakchott",
     "wof:parent_id":85674873,
     "wof:placetype":"county",

--- a/data/109/169/557/7/1091695577.geojson
+++ b/data/109/169/557/7/1091695577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.363236,
-    "geom:area_square_m":4277248429.640393,
+    "geom:area_square_m":4277248429.640317,
     "geom:bbox":"-11.5980834961,17.1773247109,-10.9705810547,18.3110961914",
     "geom:latitude":17.769035,
     "geom:longitude":-11.273399,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"MR.AS.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879547,
-    "wof:geomhash":"eff3b916d532d247332c390b6940a8e5",
+    "wof:geomhash":"32fc970b1cf1eefa744fa4039b800fef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091695577,
-    "wof:lastmodified":1566611987,
+    "wof:lastmodified":1695886848,
     "wof:name":"Boumdeid",
     "wof:parent_id":85674885,
     "wof:placetype":"county",

--- a/data/109/169/561/9/1091695619.geojson
+++ b/data/109/169/561/9/1091695619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.173878,
-    "geom:area_square_m":13825098674.929802,
+    "geom:area_square_m":13825102727.593964,
     "geom:bbox":"-13.73363,16.921692,-12.31012,18.557129",
     "geom:latitude":17.728306,
     "geom:longitude":-12.94076,
@@ -88,9 +88,10 @@
         "hasc:id":"MR.BR.ML",
         "wd:id":"Q27754050"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879548,
-    "wof:geomhash":"74264e1626355013114362dc576251e1",
+    "wof:geomhash":"349e9c1d778ee4ba13abd0cc04c4a5d2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1091695619,
-    "wof:lastmodified":1690846469,
+    "wof:lastmodified":1695886848,
     "wof:name":"Maghta Lahjar",
     "wof:parent_id":85674863,
     "wof:placetype":"county",

--- a/data/109/169/564/7/1091695647.geojson
+++ b/data/109/169/564/7/1091695647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.017518,
-    "geom:area_square_m":11975902306.942167,
+    "geom:area_square_m":11975902306.942141,
     "geom:bbox":"-12.6690063477,17.0805053711,-11.5269775391,18.8997192383",
     "geom:latitude":17.843558,
     "geom:longitude":-12.159978,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"MR.TG.MJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879550,
-    "wof:geomhash":"ba6f839e2d34fae8e238d4ddbfbbe1ad",
+    "wof:geomhash":"f0acefe9b2ccf3ac959ceaedaa2deaa0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091695647,
-    "wof:lastmodified":1566611990,
+    "wof:lastmodified":1695886849,
     "wof:name":"Moudjeria",
     "wof:parent_id":85674909,
     "wof:placetype":"county",

--- a/data/109/169/567/5/1091695675.geojson
+++ b/data/109/169/567/5/1091695675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.82255,
-    "geom:area_square_m":21394275744.377789,
+    "geom:area_square_m":21394275744.377686,
     "geom:bbox":"-16.1508883704,17.2719116211,-14.2620849609,19.0004882813",
     "geom:latitude":18.335624,
     "geom:longitude":-15.425221,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"MR.TR.ON"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879551,
-    "wof:geomhash":"5da04dab614cd6966555b8d76e2dba8f",
+    "wof:geomhash":"97eec35fedfab69bdb7cd1b46e6f5418",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091695675,
-    "wof:lastmodified":1566611987,
+    "wof:lastmodified":1695886848,
     "wof:name":"Ouad Naga",
     "wof:parent_id":85674881,
     "wof:placetype":"county",

--- a/data/109/169/569/7/1091695697.geojson
+++ b/data/109/169/569/7/1091695697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.766092,
-    "geom:area_square_m":32501864995.787659,
+    "geom:area_square_m":32501865533.368114,
     "geom:bbox":"-15.312734,16.91428,-12.669006,19.000488",
     "geom:latitude":18.13305,
     "geom:longitude":-14.122046,
@@ -143,9 +143,10 @@
     "wof:concordances":{
         "hasc:id":"MR.TR.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879552,
-    "wof:geomhash":"12fbcea549a14273b6f141169fbce77a",
+    "wof:geomhash":"7c82c6252e2d01af1f03c1118ca0d165",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1091695697,
-    "wof:lastmodified":1636494844,
+    "wof:lastmodified":1695886620,
     "wof:name":"Boutilimit",
     "wof:parent_id":85674881,
     "wof:placetype":"county",

--- a/data/109/169/573/3/1091695733.geojson
+++ b/data/109/169/573/3/1091695733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.628666,
-    "geom:area_square_m":19082792491.552982,
+    "geom:area_square_m":19082792491.553261,
     "geom:bbox":"-12.3421020508,17.1772713683,-10.9738336603,19.7114868164",
     "geom:latitude":18.627923,
     "geom:longitude":-11.551597,
@@ -149,9 +149,10 @@
     "wof:concordances":{
         "hasc:id":"MR.TG.TJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879553,
-    "wof:geomhash":"0f495d0355b04f815a272623ae9f9365",
+    "wof:geomhash":"3fe3e8b314d44e057bb3a58d78fa5355",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1091695733,
-    "wof:lastmodified":1566611990,
+    "wof:lastmodified":1695886849,
     "wof:name":"Tidjikja",
     "wof:parent_id":85674909,
     "wof:placetype":"county",

--- a/data/109/169/576/7/1091695767.geojson
+++ b/data/109/169/576/7/1091695767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.474863,
-    "geom:area_square_m":64162631579.734459,
+    "geom:area_square_m":64162642493.157333,
     "geom:bbox":"-11.079407,17.282288,-7.98761,19.725525",
     "geom:latitude":18.692409,
     "geom:longitude":-9.720653,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"MR.TG.TC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879555,
-    "wof:geomhash":"7497de75d7fd54d82d6a406e2e04e09e",
+    "wof:geomhash":"6794c2ea7b8909267f15a5d6cce8944d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1091695767,
-    "wof:lastmodified":1627522382,
+    "wof:lastmodified":1695886033,
     "wof:name":"Tichitt",
     "wof:parent_id":85674909,
     "wof:placetype":"county",

--- a/data/109/169/582/5/1091695825.geojson
+++ b/data/109/169/582/5/1091695825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.09049,
-    "geom:area_square_m":24378120414.907661,
+    "geom:area_square_m":24378120414.907623,
     "geom:bbox":"-14.2216796875,18.5571289063,-11.8907176933,20.6333007812",
     "geom:latitude":19.420463,
     "geom:longitude":-13.093494,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"MR.AD.AO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879557,
-    "wof:geomhash":"b6d7340e623f47e4d817b6538cc8b7c4",
+    "wof:geomhash":"9dd229730559fa1242862410efbc5359",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091695825,
-    "wof:lastmodified":1566611993,
+    "wof:lastmodified":1695886849,
     "wof:name":"Aoujeft",
     "wof:parent_id":85674899,
     "wof:placetype":"county",

--- a/data/109/169/585/7/1091695857.geojson
+++ b/data/109/169/585/7/1091695857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.059657,
-    "geom:area_square_m":58739602678.756958,
+    "geom:area_square_m":58739608330.443787,
     "geom:bbox":"-12.849334,19.179851,-7.52948,21.119324",
     "geom:latitude":20.141696,
     "geom:longitude":-10.455727,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"MR.AD.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879558,
-    "wof:geomhash":"a582608157287e0f07c2de607929e08d",
+    "wof:geomhash":"a9d94423eeabc99dfa22676eaaa6d4af",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1091695857,
-    "wof:lastmodified":1627522382,
+    "wof:lastmodified":1695886033,
     "wof:name":"Chinguity",
     "wof:parent_id":85674899,
     "wof:placetype":"county",

--- a/data/109/169/589/1/1091695891.geojson
+++ b/data/109/169/589/1/1091695891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.387767,
-    "geom:area_square_m":39355664295.981285,
+    "geom:area_square_m":39355679411.786148,
     "geom:bbox":"-16.035234,18.996271,-14.154419,21.150871",
     "geom:latitude":20.028239,
     "geom:longitude":-14.995566,
@@ -161,9 +161,10 @@
     "wof:concordances":{
         "hasc:id":"MR.IN.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879559,
-    "wof:geomhash":"ef1422298e6d2679adb45248cc4576cf",
+    "wof:geomhash":"37e0c0bbff7598ce25e3993d2a3b5102",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":1091695891,
-    "wof:lastmodified":1636494845,
+    "wof:lastmodified":1695886620,
     "wof:name":"Akjoujt",
     "wof:parent_id":85674869,
     "wof:placetype":"county",

--- a/data/109/169/596/1/1091695961.geojson
+++ b/data/109/169/596/1/1091695961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.992524,
-    "geom:area_square_m":23071090177.209373,
+    "geom:area_square_m":23071087810.476261,
     "geom:bbox":"-17.066534,18.600171,-14.154419,21.343671",
     "geom:latitude":20.5336,
     "geom:longitude":-15.967023,
@@ -206,9 +206,10 @@
     "wof:concordances":{
         "hasc:id":"MR.DN.ND"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879561,
-    "wof:geomhash":"d39729f5dbfa6af0dbfbf0066610f28e",
+    "wof:geomhash":"8de066af9fcb2f3811313ca04d164b86",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -218,7 +219,7 @@
         }
     ],
     "wof:id":1091695961,
-    "wof:lastmodified":1636494845,
+    "wof:lastmodified":1695886620,
     "wof:name":"Nouadhibou",
     "wof:parent_id":85674865,
     "wof:placetype":"county",

--- a/data/109/169/598/1/1091695981.geojson
+++ b/data/109/169/598/1/1091695981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.202111,
-    "geom:area_square_m":25471599996.988884,
+    "geom:area_square_m":25471592757.884003,
     "geom:bbox":"-14.301084,19.428711,-12.377991,21.577571",
     "geom:latitude":20.688612,
     "geom:longitude":-13.457242,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"MR.AD.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879563,
-    "wof:geomhash":"c39cf2636f07592f0c19fa067000e9c6",
+    "wof:geomhash":"7956ffb745cbc944c6967bc5ed10e01d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091695981,
-    "wof:lastmodified":1636494846,
+    "wof:lastmodified":1695886621,
     "wof:name":"Atar",
     "wof:parent_id":85674899,
     "wof:placetype":"county",

--- a/data/109/169/600/7/1091696007.geojson
+++ b/data/109/169/600/7/1091696007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038231,
-    "geom:area_square_m":436214633.145051,
+    "geom:area_square_m":436214634.316218,
     "geom:bbox":"-12.474434,22.557571,-12.132134,22.785771",
     "geom:latitude":22.669167,
     "geom:longitude":-12.288056,
@@ -84,9 +84,10 @@
         "hasc:id":"MR.TZ.ZO",
         "wd:id":"Q27754083"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879564,
-    "wof:geomhash":"9f8d9ebefc6bde733b6a29d28337faa3",
+    "wof:geomhash":"5e9b86f8280cb78cdc615b8fbceaa962",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091696007,
-    "wof:lastmodified":1690846471,
+    "wof:lastmodified":1695886033,
     "wof:name":"Zoueratt",
     "wof:parent_id":85674857,
     "wof:placetype":"county",

--- a/data/109/169/603/9/1091696039.geojson
+++ b/data/109/169/603/9/1091696039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.475458,
-    "geom:area_square_m":134039093994.513336,
+    "geom:area_square_m":134039093994.513153,
     "geom:bbox":"-9.14959716797,16.6355713683,-5.64433366027,23.1572686945",
     "geom:latitude":18.994378,
     "geom:longitude":-7.055733,
@@ -153,9 +153,10 @@
     "wof:concordances":{
         "hasc:id":"MR.AD.OD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879565,
-    "wof:geomhash":"7fe4fd76d3d2f4eefc296933833a9e14",
+    "wof:geomhash":"406efbca67c493017bcaa98f7fd5ae90",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1091696039,
-    "wof:lastmodified":1566611988,
+    "wof:lastmodified":1695886849,
     "wof:name":"Oualata",
     "wof:parent_id":85674901,
     "wof:placetype":"county",

--- a/data/109/169/607/3/1091696073.geojson
+++ b/data/109/169/607/3/1091696073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.951058,
-    "geom:area_square_m":113994659367.452545,
+    "geom:area_square_m":113994659367.452515,
     "geom:bbox":"-12.4631958008,20.4923095703,-6.35462866914,24.3067713683",
     "geom:latitude":21.869131,
     "geom:longitude":-8.769049,
@@ -138,9 +138,10 @@
     "wof:concordances":{
         "hasc:id":"MR.AD.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879566,
-    "wof:geomhash":"24d7b6ad1a71c4e59e59700676ef1a1f",
+    "wof:geomhash":"82b007f419e37feaf1def999271a1be0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1091696073,
-    "wof:lastmodified":1566611992,
+    "wof:lastmodified":1695886849,
     "wof:name":"Ouadane",
     "wof:parent_id":85674899,
     "wof:placetype":"county",

--- a/data/109/169/609/7/1091696097.geojson
+++ b/data/109/169/609/7/1091696097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":15.214205,
-    "geom:area_square_m":172783771186.966064,
+    "geom:area_square_m":172783731733.51532,
     "geom:bbox":"-13.145234,21.351685,-6.485534,25.007171",
     "geom:latitude":23.457146,
     "geom:longitude":-10.188538,
@@ -84,9 +84,10 @@
         "hasc:id":"MR.TZ.FD",
         "wd:id":"Q27754083"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879567,
-    "wof:geomhash":"5e2fe8c7472c02795b148df6a83a9265",
+    "wof:geomhash":"cb9aa0a1411d153c1928641e29e7a498",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091696097,
-    "wof:lastmodified":1690846471,
+    "wof:lastmodified":1695886034,
     "wof:name":"F'Derik",
     "wof:parent_id":85674857,
     "wof:placetype":"county",

--- a/data/109/169/611/7/1091696117.geojson
+++ b/data/109/169/611/7/1091696117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.819684,
-    "geom:area_square_m":87153555080.320572,
+    "geom:area_square_m":87153555349.461777,
     "geom:bbox":"-12.005634,24.996771,-4.834434,27.298071",
     "geom:latitude":25.659261,
     "geom:longitude":-8.63016,
@@ -120,9 +120,10 @@
         "hasc:id":"MR.TZ.BM",
         "wd:id":"Q27754076"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MR",
     "wof:created":1473879568,
-    "wof:geomhash":"d9cc54b2cf06624b79f1a3c5f18240c7",
+    "wof:geomhash":"8440d82382eeae802faddc0e8e834bad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1091696117,
-    "wof:lastmodified":1690846470,
+    "wof:lastmodified":1695886620,
     "wof:name":"Bir Mogrein",
     "wof:parent_id":85674857,
     "wof:placetype":"county",

--- a/data/856/326/79/85632679.geojson
+++ b/data/856/326/79/85632679.geojson
@@ -1210,6 +1210,7 @@
         "hasc:id":"MR",
         "icao:code":"5T",
         "ioc:id":"MTN",
+        "iso:code":"MR",
         "itu:id":"MTN",
         "loc:id":"n79061287",
         "m49:code":"478",
@@ -1224,6 +1225,7 @@
         "wk:page":"Mauritania",
         "wmo:id":"MT"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:country_alpha3":"MRT",
     "wof:geom_alt":[
@@ -1245,7 +1247,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639499,
+    "wof:lastmodified":1695881153,
     "wof:name":"Mauritania",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/748/57/85674857.geojson
+++ b/data/856/748/57/85674857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":23.07212,
-    "geom:area_square_m":260373540900.431549,
+    "geom:area_square_m":260373501717.293396,
     "geom:bbox":"-13.145234,21.351685,-4.834434,27.298071",
     "geom:latitude":24.202189,
     "geom:longitude":-9.663846,
@@ -288,17 +288,19 @@
         "gn:id":2375989,
         "gp:id":2346251,
         "hasc:id":"MR.TZ",
+        "iso:code":"MR-11",
         "iso:id":"MR-11",
         "qs_pg:id":922809,
         "unlc:id":"MR-11",
         "wd:id":"Q859567",
         "wk:page":"Tiris Zemmour Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"91c42cbb4400d25475abb6b2a2909734",
+    "wof:geomhash":"0698382e7c0346ff397645e678b57f47",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -313,7 +315,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690846465,
+    "wof:lastmodified":1695884778,
     "wof:name":"Tiris Zemmour",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/63/85674863.geojson
+++ b/data/856/748/63/85674863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.813746,
-    "geom:area_square_m":33224025477.163208,
+    "geom:area_square_m":33224024558.764568,
     "geom:bbox":"-14.952271,16.107117,-12.31012,18.557129",
     "geom:latitude":17.249921,
     "geom:longitude":-13.400989,
@@ -285,17 +285,19 @@
         "gn:id":2380635,
         "gp:id":2346245,
         "hasc:id":"MR.BR",
+        "iso:code":"MR-5",
         "iso:id":"MR-5",
         "qs_pg:id":1222619,
         "unlc:id":"MR-05",
         "wd:id":"Q12632",
         "wk:page":"Brakna Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"41143f6e3421158cfc111a9f4ebc9755",
+    "wof:geomhash":"976e00062295986496e64da2dd27c86e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -310,7 +312,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690846468,
+    "wof:lastmodified":1695884778,
     "wof:name":"Brakna",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/65/85674865.geojson
+++ b/data/856/748/65/85674865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.992524,
-    "geom:area_square_m":23071090177.209373,
+    "geom:area_square_m":23071087810.476261,
     "geom:bbox":"-17.066534,18.600171,-14.154419,21.343671",
     "geom:latitude":20.5336,
     "geom:longitude":-15.967023,
@@ -287,16 +287,18 @@
         "gn:id":2380426,
         "gp:id":2346248,
         "hasc:id":"MR.DN",
+        "iso:code":"MR-8",
         "iso:id":"MR-8",
         "qs_pg:id":1046934,
         "wd:id":"Q859573",
         "wk:page":"Dakhlet Nouadhibou Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d39729f5dbfa6af0dbfbf0066610f28e",
+    "wof:geomhash":"8de066af9fcb2f3811313ca04d164b86",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690846467,
+    "wof:lastmodified":1695884778,
     "wof:name":"Dakhlet Nouadhibou",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/69/85674869.geojson
+++ b/data/856/748/69/85674869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.387767,
-    "geom:area_square_m":39355664295.981285,
+    "geom:area_square_m":39355679411.786148,
     "geom:bbox":"-16.035234,18.996271,-14.154419,21.150871",
     "geom:latitude":20.028239,
     "geom:longitude":-14.995566,
@@ -286,17 +286,19 @@
         "gn:id":2378903,
         "gp:id":2346252,
         "hasc:id":"MR.IN",
+        "iso:code":"MR-12",
         "iso:id":"MR-12",
         "qs_pg:id":235611,
         "unlc:id":"MR-12",
         "wd:id":"Q850022",
         "wk:page":"Inchiri Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ef1422298e6d2679adb45248cc4576cf",
+    "wof:geomhash":"37e0c0bbff7598ce25e3993d2a3b5102",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690846466,
+    "wof:lastmodified":1695884778,
     "wof:name":"Inchiri",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/73/85674873.geojson
+++ b/data/856/748/73/85674873.geojson
@@ -573,10 +573,12 @@
         "gn:id":2377449,
         "gp:id":24550716,
         "hasc:id":"MR.NW",
+        "iso:code_pseudo":"MR-14",
         "qs_pg:id":1086156,
         "unlc:id":"MR-NKC",
         "wd:id":"Q859581"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:coterminous":[
         1091695565,
         421189891
@@ -600,7 +602,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493173,
+    "wof:lastmodified":1695884477,
     "wof:name":"Nouakchott",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/81/85674881.geojson
+++ b/data/856/748/81/85674881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.929308,
-    "geom:area_square_m":69754795260.566879,
+    "geom:area_square_m":69754792054.174164,
     "geom:bbox":"-16.515234,16.062317,-12.669006,19.000488",
     "geom:latitude":17.924023,
     "geom:longitude":-14.855242,
@@ -284,17 +284,19 @@
         "gn:id":2375742,
         "gp:id":2346246,
         "hasc:id":"MR.TR",
+        "iso:code":"MR-6",
         "iso:id":"MR-6",
         "qs_pg:id":235612,
         "unlc:id":"MR-06",
         "wd:id":"Q859581",
         "wk:page":"Trarza Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3468ca3f36517bf84989abac37f8cda6",
+    "wof:geomhash":"878612ed7d48457ef835f77522222ee5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690846466,
+    "wof:lastmodified":1695884778,
     "wof:name":"Trarza",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/85/85674885.geojson
+++ b/data/856/748/85/85674885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.038952,
-    "geom:area_square_m":36012412338.787354,
+    "geom:area_square_m":36012420224.690048,
     "geom:bbox":"-12.838989,15.105271,-10.582583,18.311096",
     "geom:latitude":16.579991,
     "geom:longitude":-11.535914,
@@ -288,17 +288,19 @@
         "gn:id":2381344,
         "gp:id":2346243,
         "hasc:id":"MR.AS",
+        "iso:code":"MR-3",
         "iso:id":"MR-3",
         "qs_pg:id":318534,
         "unlc:id":"MR-03",
         "wd:id":"Q738546",
         "wk:page":"Assaba Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fb9813c80c6dae4f6534175128bbe286",
+    "wof:geomhash":"cfde771d36b4f4f4840e8f898d5c9205",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -313,7 +315,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690846468,
+    "wof:lastmodified":1695885133,
     "wof:name":"Assaba",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/87/85674887.geojson
+++ b/data/856/748/87/85674887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.903659,
-    "geom:area_square_m":10773767472.386581,
+    "geom:area_square_m":10773766869.575733,
     "geom:bbox":"-12.748718,14.718971,-11.500305,16.056274",
     "geom:latitude":15.375668,
     "geom:longitude":-12.12595,
@@ -285,17 +285,19 @@
         "gn:id":2379216,
         "gp:id":2346250,
         "hasc:id":"MR.GD",
+        "iso:code":"MR-10",
         "iso:id":"MR-10",
         "qs_pg:id":1065879,
         "unlc:id":"MR-10",
         "wd:id":"Q768119",
         "wk:page":"Guidimaka Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4b3467904f6246763b3aaa53c86166ff",
+    "wof:geomhash":"4bdf3ca2e9eef2ac0dcdf19a626af002",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -310,7 +312,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690846466,
+    "wof:lastmodified":1695884778,
     "wof:name":"Guidimaka",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/91/85674891.geojson
+++ b/data/856/748/91/85674891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.168783,
-    "geom:area_square_m":13891861871.144527,
+    "geom:area_square_m":13891862846.965429,
     "geom:bbox":"-13.713196,15.124084,-12.004822,16.859314",
     "geom:latitude":16.004972,
     "geom:longitude":-12.836737,
@@ -285,17 +285,19 @@
         "gn:id":2379384,
         "gp:id":2346244,
         "hasc:id":"MR.GO",
+        "iso:code":"MR-4",
         "iso:id":"MR-4",
         "qs_pg:id":91354,
         "unlc:id":"MR-04",
         "wd:id":"Q859831",
         "wk:page":"Gorgol Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"da06c31b2595112016cd7061814ffd29",
+    "wof:geomhash":"4b57791280487aa7ecf04e9b9028f5d6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -310,7 +312,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690846467,
+    "wof:lastmodified":1695884778,
     "wof:name":"Gorgol",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/748/99/85674899.geojson
+++ b/data/856/748/99/85674899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":19.303319,
-    "geom:area_square_m":222583982458.105896,
+    "geom:area_square_m":222583996561.434479,
     "geom:bbox":"-14.301084,18.557129,-6.354629,24.306771",
     "geom:latitude":21.016491,
     "geom:longitude":-10.2143,
@@ -294,17 +294,19 @@
         "gn:id":2381972,
         "gp:id":2346247,
         "hasc:id":"MR.AD",
+        "iso:code":"MR-7",
         "iso:id":"MR-7",
         "qs_pg:id":894923,
         "unlc:id":"MR-07",
         "wd:id":"Q366626",
         "wk:page":"Adrar Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8aff45d602e136b68898133bf7d77be3",
+    "wof:geomhash":"d084201125216f4ac01057e2572f2d6a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -319,7 +321,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690846467,
+    "wof:lastmodified":1695884778,
     "wof:name":"Adrar",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/749/01/85674901.geojson
+++ b/data/856/749/01/85674901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":15.923832,
-    "geom:area_square_m":186875325595.421204,
+    "geom:area_square_m":186875288887.377045,
     "geom:bbox":"-9.149597,15.494873,-5.327134,23.157269",
     "geom:latitude":18.19586,
     "geom:longitude":-7.088263,
@@ -282,17 +282,19 @@
         "gn:id":2379025,
         "gp:id":2346241,
         "hasc:id":"MR.HC",
+        "iso:code":"MR-1",
         "iso:id":"MR-1",
         "qs_pg:id":91353,
         "unlc:id":"MR-01",
         "wd:id":"Q12621",
         "wk:page":"Hodh Ech Chargui Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7c0ce682bbc0e3485dd7faa04071126a",
+    "wof:geomhash":"e80e07db5157e59947a0bb0f9e39c6eb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -307,7 +309,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690846465,
+    "wof:lastmodified":1695884331,
     "wof:name":"Hodh Ech Chargi",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/749/05/85674905.geojson
+++ b/data/856/749/05/85674905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.234999,
-    "geom:area_square_m":50188564986.990776,
+    "geom:area_square_m":50188571379.013115,
     "geom:bbox":"-11.095825,15.419871,-8.289185,17.7229",
     "geom:latitude":16.572763,
     "geom:longitude":-9.826749,
@@ -281,17 +281,19 @@
         "gn:id":2379024,
         "gp:id":2346242,
         "hasc:id":"MR.HG",
+        "iso:code":"MR-2",
         "iso:id":"MR-2",
         "qs_pg:id":984089,
         "unlc:id":"MR-02",
         "wd:id":"Q850435",
         "wk:page":"Hodh El Gharbi Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2d9f5074d9ca6590a9c6f9d7ad18f910",
+    "wof:geomhash":"90c0e615b9fdd1e765ac3ac27b2f1307",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690846465,
+    "wof:lastmodified":1695884331,
     "wof:name":"Hodh El Gharbi",
     "wof:parent_id":85632679,
     "wof:placetype":"region",

--- a/data/856/749/09/85674909.geojson
+++ b/data/856/749/09/85674909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.121046,
-    "geom:area_square_m":95221326378.229309,
+    "geom:area_square_m":95221329694.099716,
     "geom:bbox":"-12.669006,17.080505,-7.98761,19.725525",
     "geom:latitude":18.573121,
     "geom:longitude":-10.393479,
@@ -283,17 +283,19 @@
         "gn:id":2376551,
         "gp:id":2346249,
         "hasc:id":"MR.TG",
+        "iso:code":"MR-9",
         "iso:id":"MR-9",
         "qs_pg:id":922808,
         "unlc:id":"MR-09",
         "wd:id":"Q843903",
         "wk:page":"Tagant Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2e7051609b0ae7b884db376f29bb39a3",
+    "wof:geomhash":"fad46a0748380ff28d2031e6a8c51530",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -308,7 +310,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690846465,
+    "wof:lastmodified":1695884778,
     "wof:name":"Tagant",
     "wof:parent_id":85632679,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.